### PR TITLE
Make README.md examples fit typical style

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ Works in all languages
 NOTE: this will automatically blacklist the official mycroft skill
 
 ## Examples 
-* "tell me a joke"
-* "say a joke"
-* "do you know any jokes"
-* "can you tell jokes"
-* "make me laugh"
-* "tell me a joke about dentists"
-* "do you know any chuck norris jokes"
+* "Tell me a joke."
+* "Say a joke."
+* "Do you know any jokes?"
+* "Can you tell jokes?"
+* "Make me laugh."
+* "Tell me a joke about dentists."
+* "Do you know any Chuck Norris jokes?"
 
 # Platform support
 

--- a/res/desktop/skill.json
+++ b/res/desktop/skill.json
@@ -16,12 +16,12 @@
     "ia64"
   ],
   "examples": [
-    "tell me a joke",
-    "say a joke",
-    "do you know any jokes",
-    "can you tell jokes",
-    "make me laugh",
-    "tell me a joke about dentists",
-    "do you know any chuck norris jokes"
+    "Tell me a joke.",
+    "Say a joke.",
+    "Do you know any jokes?",
+    "Can you tell jokes?",
+    "Make me laugh.",
+    "Tell me a joke about dentists.",
+    "Do you know any Chuck Norris jokes?"
   ]
 }


### PR DESCRIPTION
The prior copy looked out of place in the rest of the homescreen examples, which are all capitalized and end in punctuation.