### PR TITLE
Fix invalid dependency spec from #10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ ovos_workshop~=0.0.15
 ovos_utils~=0.0,>=0.0.38
 ovos_classifiers
 pyjokes~=0.6
-ovos-translate-server-plugin~=0.0.1
+ovos-translate-server-plugin~=0.0.0

--- a/skill.json
+++ b/skill.json
@@ -18,7 +18,7 @@
     "systemDeps": false,
     "requirements": {
         "python": [
-            "ovos-translate-server-plugin~=0.0.1",
+            "ovos-translate-server-plugin~=0.0.0",
             "ovos_classifiers",
             "ovos_plugin_manager~=0.0.25",
             "ovos_utils~=0.0,>=0.0.38",


### PR DESCRIPTION
My mistake in #10 . I had found `ovos-translate-server` instead of `ovos-translate-server-plugin` and used an invalid dependency version.

Tests failing https://github.com/OpenVoiceOS/skill-ovos-icanhazdadjokes/actions/runs/8544951741