### PR TITLE
fix:allow workshop 3.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ovos-plugin-manager>=0.0.25,<1.0.0
-ovos-workshop>=0.0.15,<3.0.0
+ovos-workshop>=0.0.15,<4.0.0
 ovos-utils>=0.0.38,<1.0.0
 ovos_classifiers
 pyjokes~=0.6


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version constraint for the `ovos-workshop` package to allow for a broader range of versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->