### PR TITLE
fix: default to dad jokes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -27,7 +27,7 @@ class JokingSkill(OVOSSkill):
         elif self.lang.split("-")[0] in ["cs", "es", "eu", "gl", "hu", "it", "pl", "sv"]:
             self.speak_dialog("dev_jokes")
         else:
-            self.speak_dialog("general_jokes")
+            self.speak_dialog("dad_jokes")
 
     @intent_handler("search_joke.intent")
     def handle_search_joke(self, message: Message) -> None:


### PR DESCRIPTION
per the skill name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated dialog for general jokes to now feature "dad jokes" when language conditions are not met.
- **Bug Fixes**
	- Retained handling for "Dad" jokes to ensure consistent dialog delivery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->