### PR TITLE
feat: standardize entity slots

### DIFF
--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -19,12 +19,12 @@ jobs:
     if: success()  # Ensure this job only runs if the previous job succeeds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: master
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
       - name: Install Build Tools
@@ -47,7 +47,7 @@ jobs:
     if: success()  # Ensure this job only runs if the previous job succeeds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
           ref: master

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -48,7 +48,7 @@ jobs:
     needs: publish_alpha
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Send message to Matrix bots channel
         id: matrix-chat-message
         uses: fadenb/matrix-chat-message@v0.0.6
@@ -65,12 +65,12 @@ jobs:
     if: success()  # Ensure this job only runs if the previous job succeeds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref: dev
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
       - name: Install Build Tools
@@ -93,12 +93,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout dev branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: dev
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/__init__.py
+++ b/__init__.py
@@ -31,7 +31,7 @@ class JokingSkill(OVOSSkill):
 
     @intent_handler("search_joke.intent")
     def handle_search_joke(self, message: Message) -> None:
-        category = message.data["search"].lower()
+        category = message.data["query"].lower()
         self.log.debug("joke search: %s", category)
 
         # TODO self.voc_match more joke types
@@ -45,4 +45,4 @@ class JokingSkill(OVOSSkill):
         elif self.voc_match(voc_filename="Pun", utt=category, lang=self.lang):
             self.speak_dialog("puns")
         else:
-            self.speak_dialog("no_joke", {"search": category})
+            self.speak_dialog("no_joke", {"query": category})

--- a/locale/ca-es/no_joke.dialog
+++ b/locale/ca-es/no_joke.dialog
@@ -1,1 +1,1 @@
-no he trobat cap broma sobre {search}
+no he trobat cap broma sobre {query}

--- a/locale/ca-es/search_joke.intent
+++ b/locale/ca-es/search_joke.intent
@@ -1,9 +1,9 @@
-(broma|acudit) (de|sobre) {search}
-(diga|digue|conta|explica)'m (alguna|una) broma (de|sobre) {search}
-(diga|digue|conta|explica)'m (algun|un) acudit (de|sobre) {search}
-(una|alguna) broma (de|sobre) {search}
-(un|algun) acudit (de|sobre) {search}
-em pots (dir|contar|explicar) (bromes|acudits) (de|sobre) {search}
-pots (dir|contar|explicar)-me (bromes|acudits) (de|sobre) {search}
-saps (cap|algun) acudit (de|sobre) {search}
-saps (cap|alguna) broma (de|sobre) {search}
+(broma|acudit) (de|sobre) {query}
+(diga|digue|conta|explica)'m (alguna|una) broma (de|sobre) {query}
+(diga|digue|conta|explica)'m (algun|un) acudit (de|sobre) {query}
+(una|alguna) broma (de|sobre) {query}
+(un|algun) acudit (de|sobre) {query}
+em pots (dir|contar|explicar) (bromes|acudits) (de|sobre) {query}
+pots (dir|contar|explicar)-me (bromes|acudits) (de|sobre) {query}
+saps (cap|algun) acudit (de|sobre) {query}
+saps (cap|alguna) broma (de|sobre) {query}

--- a/locale/da-dk/no_joke.dialog
+++ b/locale/da-dk/no_joke.dialog
@@ -1,1 +1,1 @@
-jeg kunne ikke finde nogen joke om {search}
+jeg kunne ikke finde nogen joke om {query}

--- a/locale/da-dk/search_joke.intent
+++ b/locale/da-dk/search_joke.intent
@@ -1,9 +1,9 @@
-fortæl mig en vittighed om {search}
-fortæl mig en {search} joke
-joke om {search}
-kan du fortælle vittigheder om {search}
-kan du fortælle {search} vittigheder
-kender du nogle vittigheder om {search}
-kender du nogle {search} vittigheder
-sig en {search} joke
-sige en joke om {search}
+fortæl mig en vittighed om {query}
+fortæl mig en {query} joke
+joke om {query}
+kan du fortælle vittigheder om {query}
+kan du fortælle {query} vittigheder
+kender du nogle vittigheder om {query}
+kender du nogle {query} vittigheder
+sig en {query} joke
+sige en joke om {query}

--- a/locale/de-de/no_joke.dialog
+++ b/locale/de-de/no_joke.dialog
@@ -1,1 +1,1 @@
-ich konnte keinen Witz über {search} finden
+ich konnte keinen Witz über {query} finden

--- a/locale/de-de/search_joke.intent
+++ b/locale/de-de/search_joke.intent
@@ -1,9 +1,9 @@
-Mache einen Witz über {search}
-Mache einen {search} Witz
-erzähl einen {search} Witz
-erzähl mir einen Witz über {search}
-erzähl mir einen {search} Witz
-erzähle einen Witz über {search}
-kannst du Witze über {search} erzählen
-kannst du {search} Witze erzählen
-kennst du einen {search} Witz
+Mache einen Witz über {query}
+Mache einen {query} Witz
+erzähl einen {query} Witz
+erzähl mir einen Witz über {query}
+erzähl mir einen {query} Witz
+erzähle einen Witz über {query}
+kannst du Witze über {query} erzählen
+kannst du {query} Witze erzählen
+kennst du einen {query} Witz

--- a/locale/en-us/no_joke.dialog
+++ b/locale/en-us/no_joke.dialog
@@ -1,1 +1,1 @@
-i could not find any joke about {search}
+i could not find any joke about {query}

--- a/locale/en-us/search_joke.intent
+++ b/locale/en-us/search_joke.intent
@@ -1,9 +1,9 @@
-can you tell jokes about {search}
-can you tell {search} jokes
-do you know any jokes about {search}
-do you know any {search} jokes
-joke about {search}
-say a joke about {search}
-say a {search} joke
-tell me a joke about {search}
-tell me a {search} joke
+can you tell jokes about {query}
+can you tell {query} jokes
+do you know any jokes about {query}
+do you know any {query} jokes
+joke about {query}
+say a joke about {query}
+say a {query} joke
+tell me a joke about {query}
+tell me a {query} joke

--- a/locale/eu/no_joke.dialog
+++ b/locale/eu/no_joke.dialog
@@ -1,1 +1,1 @@
-Ezin izan dut {search}(r|)i buruzko txisterik aurkitu
+Ezin izan dut {query}(r|)i buruzko txisterik aurkitu

--- a/locale/eu/search_joke.intent
+++ b/locale/eu/search_joke.intent
@@ -1,9 +1,9 @@
-badakizu txiste {search}
-badakizu {search} buruzko txisterik
-konta dezakezu txiste {search}
-konta ditzakezu honi buruzko txisteak {search}
-kontadazu txiste {search} bat
-kontadazu {search} buruzko txiste bat
-kontatu txiste {search} bat
-kontatu {search} buruzko txiste bat
-{search} buruzko txistea
+badakizu txiste {query}
+badakizu {query} buruzko txisterik
+konta dezakezu txiste {query}
+konta ditzakezu honi buruzko txisteak {query}
+kontadazu txiste {query} bat
+kontadazu {query} buruzko txiste bat
+kontatu txiste {query} bat
+kontatu {query} buruzko txiste bat
+{query} buruzko txistea

--- a/locale/fr-fr/no_joke.dialog
+++ b/locale/fr-fr/no_joke.dialog
@@ -1,1 +1,1 @@
-je n'ai trouvé aucune blague sur {search}
+je n'ai trouvé aucune blague sur {query}

--- a/locale/fr-fr/search_joke.intent
+++ b/locale/fr-fr/search_joke.intent
@@ -1,5 +1,5 @@
-Connais-tu des blagues sur {search}
-blague sur {search}
-dis une blague sur {search}
-peux-tu raconter des blagues sur {search}
-raconte-moi une blague sur {search}
+Connais-tu des blagues sur {query}
+blague sur {query}
+dis une blague sur {query}
+peux-tu raconter des blagues sur {query}
+raconte-moi une blague sur {query}

--- a/locale/gl-es/no_joke.dialog
+++ b/locale/gl-es/no_joke.dialog
@@ -1,1 +1,1 @@
-non dei atopado ningunha brincadeira sobre {search}
+non dei atopado ningunha brincadeira sobre {query}

--- a/locale/gl-es/search_joke.intent
+++ b/locale/gl-es/search_joke.intent
@@ -1,9 +1,9 @@
-conta un chiste de {search}
-conta un chiste sobre {search}
-cóntame un chiste de {search}
-cóntame un chiste sobre {search}
-di un chiste de {search}
-sabes algún chiste de {search}
-sabes algún chiste sobre {search}
-sabes chistes sobre {search}
-sabes contar chistes sobre {search}
+conta un chiste de {query}
+conta un chiste sobre {query}
+cóntame un chiste de {query}
+cóntame un chiste sobre {query}
+di un chiste de {query}
+sabes algún chiste de {query}
+sabes algún chiste sobre {query}
+sabes chistes sobre {query}
+sabes contar chistes sobre {query}

--- a/locale/pt-pt/no_joke.dialog
+++ b/locale/pt-pt/no_joke.dialog
@@ -1,1 +1,1 @@
-não encontrei nenhuma (anedota|piada) sobre {search}
+não encontrei nenhuma (anedota|piada) sobre {query}

--- a/locale/pt-pt/search_joke.intent
+++ b/locale/pt-pt/search_joke.intent
@@ -1,3 +1,3 @@
-(conta|conta-me|diz-me) uma (piada|anedota) sobre {search}
-(piada|anedota) sobre {search}
-sabes alguma (piada|anedota) sobre {search}
+(conta|conta-me|diz-me) uma (piada|anedota) sobre {query}
+(piada|anedota) sobre {query}
+sabes alguma (piada|anedota) sobre {query}

--- a/translations/ca-es/dialogs.json
+++ b/translations/ca-es/dialogs.json
@@ -1,5 +1,5 @@
 {
     "no_joke.dialog": [
-        "no he trobat cap broma sobre {search}"
+        "no he trobat cap broma sobre {query}"
     ]
 }

--- a/translations/ca-es/intents.json
+++ b/translations/ca-es/intents.json
@@ -1,14 +1,14 @@
 {
     "search_joke.intent": [
-        "(broma|acudit) (de|sobre) {search}",
-        "(diga|digue|conta|explica)'m (alguna|una) broma (de|sobre) {search}",
-        "(diga|digue|conta|explica)'m (algun|un) acudit (de|sobre) {search}",
-        "(una|alguna) broma (de|sobre) {search}",
-        "(un|algun) acudit (de|sobre) {search}",
-        "em pots (dir|contar|explicar) (bromes|acudits) (de|sobre) {search}",
-        "pots (dir|contar|explicar)-me (bromes|acudits) (de|sobre) {search}",
-        "saps (cap|algun) acudit (de|sobre) {search}",
-        "saps (cap|alguna) broma (de|sobre) {search}"
+        "(broma|acudit) (de|sobre) {query}",
+        "(diga|digue|conta|explica)'m (alguna|una) broma (de|sobre) {query}",
+        "(diga|digue|conta|explica)'m (algun|un) acudit (de|sobre) {query}",
+        "(una|alguna) broma (de|sobre) {query}",
+        "(un|algun) acudit (de|sobre) {query}",
+        "em pots (dir|contar|explicar) (bromes|acudits) (de|sobre) {query}",
+        "pots (dir|contar|explicar)-me (bromes|acudits) (de|sobre) {query}",
+        "saps (cap|algun) acudit (de|sobre) {query}",
+        "saps (cap|alguna) broma (de|sobre) {query}"
     ],
     "joke.intent": [
         "(conta|diga|digue|explica) (alguna|una) broma",

--- a/translations/da-dk/dialogs.json
+++ b/translations/da-dk/dialogs.json
@@ -1,5 +1,5 @@
 {
     "no_joke.dialog": [
-        "jeg kunne ikke finde nogen joke om {search}"
+        "jeg kunne ikke finde nogen joke om {query}"
     ]
 }

--- a/translations/da-dk/intents.json
+++ b/translations/da-dk/intents.json
@@ -1,14 +1,14 @@
 {
     "search_joke.intent": [
-        "fortæl mig en vittighed om {search}",
-        "fortæl mig en {search} joke",
-        "joke om {search}",
-        "kan du fortælle vittigheder om {search}",
-        "kan du fortælle {search} vittigheder",
-        "kender du nogle vittigheder om {search}",
-        "kender du nogle {search} vittigheder",
-        "sig en {search} joke",
-        "sige en joke om {search}"
+        "fortæl mig en vittighed om {query}",
+        "fortæl mig en {query} joke",
+        "joke om {query}",
+        "kan du fortælle vittigheder om {query}",
+        "kan du fortælle {query} vittigheder",
+        "kender du nogle vittigheder om {query}",
+        "kender du nogle {query} vittigheder",
+        "sig en {query} joke",
+        "sige en joke om {query}"
     ],
     "joke.intent": [
         "fortæl mig en vittighed",

--- a/translations/de-de/dialogs.json
+++ b/translations/de-de/dialogs.json
@@ -3,7 +3,7 @@
 
   ],
   "no_joke.dialog": [
-    "ich konnte keinen Witz über {search} finden"
+    "ich konnte keinen Witz über {query} finden"
   ],
   "general_jokes.dialog": [
     "Was steht auf dem Grabstein eines Mathematikers? 'Damit hat er nicht gerechnet.'",

--- a/translations/de-de/intents.json
+++ b/translations/de-de/intents.json
@@ -1,14 +1,14 @@
 {
   "search_joke.intent": [
-    "Mache einen Witz über {search}",
-    "Mache einen {search} Witz",
-    "erzähl einen {search} Witz",
-    "erzähl mir einen Witz über {search}",
-    "erzähl mir einen {search} Witz",
-    "erzähle einen Witz über {search}",
-    "kannst du Witze über {search} erzählen",
-    "kannst du {search} Witze erzählen",
-    "kennst du einen {search} Witz"
+    "Mache einen Witz über {query}",
+    "Mache einen {query} Witz",
+    "erzähl einen {query} Witz",
+    "erzähl mir einen Witz über {query}",
+    "erzähl mir einen {query} Witz",
+    "erzähle einen Witz über {query}",
+    "kannst du Witze über {query} erzählen",
+    "kannst du {query} Witze erzählen",
+    "kennst du einen {query} Witz"
   ],
   "joke.intent": [
     "Bring mich zum Lachen",

--- a/translations/en-us/dialogs.json
+++ b/translations/en-us/dialogs.json
@@ -1,7 +1,7 @@
 {
     "blondes_jokes.dialog": [],
     "no_joke.dialog": [
-        "i could not find any joke about {search}"
+        "i could not find any joke about {query}"
     ],
     "general_jokes.dialog": [
         "What is written on the gravestone of a mathematician? \"He didn’t calculate this.\"",

--- a/translations/en-us/intents.json
+++ b/translations/en-us/intents.json
@@ -1,14 +1,14 @@
 {
     "search_joke.intent": [
-        "can you tell jokes about {search}",
-        "can you tell {search} jokes",
-        "do you know any jokes about {search}",
-        "do you know any {search} jokes",
-        "joke about {search}",
-        "say a joke about {search}",
-        "say a {search} joke",
-        "tell me a joke about {search}",
-        "tell me a {search} joke"
+        "can you tell jokes about {query}",
+        "can you tell {query} jokes",
+        "do you know any jokes about {query}",
+        "do you know any {query} jokes",
+        "joke about {query}",
+        "say a joke about {query}",
+        "say a {query} joke",
+        "tell me a joke about {query}",
+        "tell me a {query} joke"
     ],
     "joke.intent": [
         "can you tell jokes",

--- a/translations/eu/dialogs.json
+++ b/translations/eu/dialogs.json
@@ -9,6 +9,6 @@
         "Zer da terapeuta bat? - 1024 Gigapeuta"
     ],
     "no_joke.dialog": [
-        "Ezin izan dut {search}(r|)i buruzko txisterik aurkitu"
+        "Ezin izan dut {query}(r|)i buruzko txisterik aurkitu"
     ]
 }

--- a/translations/eu/intents.json
+++ b/translations/eu/intents.json
@@ -1,14 +1,14 @@
 {
     "search_joke.intent": [
-        "badakizu txiste {search}",
-        "badakizu {search} buruzko txisterik",
-        "konta dezakezu txiste {search}",
-        "konta ditzakezu honi buruzko txisteak {search}",
-        "kontadazu txiste {search} bat",
-        "kontadazu {search} buruzko txiste bat",
-        "kontatu txiste {search} bat",
-        "kontatu {search} buruzko txiste bat",
-        "{search} buruzko txistea"
+        "badakizu txiste {query}",
+        "badakizu {query} buruzko txisterik",
+        "konta dezakezu txiste {query}",
+        "konta ditzakezu honi buruzko txisteak {query}",
+        "kontadazu txiste {query} bat",
+        "kontadazu {query} buruzko txiste bat",
+        "kontatu txiste {query} bat",
+        "kontatu {query} buruzko txiste bat",
+        "{query} buruzko txistea"
     ],
     "joke.intent": [
         "badakizu txisterik",

--- a/translations/fr-fr/dialogs.json
+++ b/translations/fr-fr/dialogs.json
@@ -985,7 +985,7 @@
         "Le jour de sa mort, Kennedy s'est dit qu'il était bon de sortir en voiture. Car ça permet de se vider la tête."
     ],
     "no_joke.dialog": [
-        "je n'ai trouvé aucune blague sur {search}"
+        "je n'ai trouvé aucune blague sur {query}"
     ],
     "general_jokes.dialog": [
         "Qu'est-ce qui est bleu, blanc et rouge ? Un schtroumf qui saigne du nez.",

--- a/translations/fr-fr/intents.json
+++ b/translations/fr-fr/intents.json
@@ -1,10 +1,10 @@
 {
     "search_joke.intent": [
-        "Connais-tu des blagues sur {search}",
-        "blague sur {search}",
-        "dis une blague sur {search}",
-        "peux-tu raconter des blagues sur {search}",
-        "raconte-moi une blague sur {search}"
+        "Connais-tu des blagues sur {query}",
+        "blague sur {query}",
+        "dis une blague sur {query}",
+        "peux-tu raconter des blagues sur {query}",
+        "raconte-moi une blague sur {query}"
     ],
     "joke.intent": [
         "connais-tu des blagues",

--- a/translations/gl-es/dialogs.json
+++ b/translations/gl-es/dialogs.json
@@ -1,7 +1,7 @@
 {
     "blondes_jokes.dialog": [],
     "no_joke.dialog": [
-        "non dei atopado ningunha brincadeira sobre {search}"
+        "non dei atopado ningunha brincadeira sobre {query}"
     ],
     "general_jokes.dialog": [],
     "chuck_norris_jokes.dialog": [],

--- a/translations/gl-es/intents.json
+++ b/translations/gl-es/intents.json
@@ -1,14 +1,14 @@
 {
     "search_joke.intent": [
-        "conta un chiste de {search}",
-        "conta un chiste sobre {search}",
-        "cóntame un chiste de {search}",
-        "cóntame un chiste sobre {search}",
-        "di un chiste de {search}",
-        "sabes algún chiste de {search}",
-        "sabes algún chiste sobre {search}",
-        "sabes chistes sobre {search}",
-        "sabes contar chistes sobre {search}"
+        "conta un chiste de {query}",
+        "conta un chiste sobre {query}",
+        "cóntame un chiste de {query}",
+        "cóntame un chiste sobre {query}",
+        "di un chiste de {query}",
+        "sabes algún chiste de {query}",
+        "sabes algún chiste sobre {query}",
+        "sabes chistes sobre {query}",
+        "sabes contar chistes sobre {query}"
     ],
     "joke.intent": [
         "cóntame un chiste",

--- a/translations/pt-pt/dialogs.json
+++ b/translations/pt-pt/dialogs.json
@@ -3,7 +3,7 @@
 
   ],
   "no_joke.dialog": [
-    "não encontrei nenhuma (anedota|piada) sobre {search}"
+    "não encontrei nenhuma (anedota|piada) sobre {query}"
   ],
   "general_jokes.dialog": [
     "O que está escrito na lápide de um matemático? \"Ele não calculou isso.\"",

--- a/translations/pt-pt/intents.json
+++ b/translations/pt-pt/intents.json
@@ -1,8 +1,8 @@
 {
     "search_joke.intent": [
-        "(conta|conta-me|diz-me) uma (piada|anedota) sobre {search}",
-        "(piada|anedota) sobre {search}",
-        "sabes alguma (piada|anedota) sobre {search}"
+        "(conta|conta-me|diz-me) uma (piada|anedota) sobre {query}",
+        "(piada|anedota) sobre {query}",
+        "sabes alguma (piada|anedota) sobre {query}"
     ],
     "joke.intent": [
         "(conta|diz|conta-me|diz-me) uma (piada|anedota)",


### PR DESCRIPTION
use same nomenclature for capture groups across skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized the placeholder variable from `{search}` to `{query}` across all supported languages in joke search intents and no-joke response messages for consistent user experience.

- **Chores**
  - Upgraded GitHub Actions workflows to the latest versions of checkout and Python setup actions to enhance stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->